### PR TITLE
Updates to RabbitMQQueue to use exchange_name config value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+/nbproject

--- a/src/examples/queue.php
+++ b/src/examples/queue.php
@@ -89,6 +89,7 @@ return [
 				'durable'     => env('RABBITMQ_QUEUE_DURABLE', true),
 				'exclusive'   => env('RABBITMQ_QUEUE_EXCLUSIVE', false),
 				'auto_delete' => env('RABBITMQ_QUEUE_AUTODELETE', false),
+				'routing_key' => env('RABBITMQ_QUEUE_ROUTING_KEY', ''),
 			],
 
 			'exchange_params' => [


### PR DESCRIPTION
During some recent Laravel 5 development to replace an existing php queue publisher and consumer, I ran into some issues with the use of the exchange_name config value. This pull requests contains the changes I made in order to get the queue driver working as documented. I have made sure that the fallback behaviour is bc with the current implementation.

I have also allowed for the creation of a routing key config on a per queue basis as opposed to forcing the name of the queue. AMQPConnection has also been updated to AMQPStreamConnection as the former is now deprecated.