### PR TITLE
Expose message properties

### DIFF
--- a/src/FintechFab/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/FintechFab/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -123,4 +123,25 @@ class RabbitMQJob extends Job implements JobContract
 		return $this->message->get('correlation_id');
 	}
 
+	/**
+	 * Wrapper for {@link \PhpAmqpLib\Wire\GenericContent::get_properties()}
+	 *
+	 * @return array
+	 * @see \PhpAmqpLib\Wire\GenericContent::get_properties()
+	 */
+	public function getProperties() {
+		return $this->message->get_properties();
+	}
+
+	/**
+	 * Wrapper for {@link \PhpAmqpLib\Wire\GenericContent::get()}
+	 *
+	 * @param $name string
+	 * @return mixed|\PhpAmqpLib\Channel\AMQPChannel
+	 * @see \PhpAmqpLib\Wire\GenericContent::get()
+	 */
+	public function getProperty($name) {
+		return $this->message->get($name);
+	}
+
 }

--- a/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -72,7 +72,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
 		// push job to a queue
 		$message = new AMQPMessage($payload, [
-			'Content-Type'  => 'application/json',
+			'content_type'  => 'application/json',
 			'delivery_mode' => 2,
 		]);
 

--- a/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/FintechFab/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -70,11 +70,16 @@ class RabbitMQQueue extends Queue implements QueueContract
 			$queue = $this->declareDelayedQueue($queue, $options['delay']);
 		}
 
-		// push job to a queue
-		$message = new AMQPMessage($payload, [
+		$properties = [
 			'content_type'  => 'application/json',
 			'delivery_mode' => 2,
-		]);
+		];
+		if (isset($options['properties']) && is_array($options['properties'])) {
+			$properties = $properties + $options['properties'];
+		}
+
+		// push job to a queue
+		$message = new AMQPMessage($payload, $properties);
 
 		// push task to a queue
 		$this->channel->basic_publish($message, $exchange, $queue);


### PR DESCRIPTION
This provides access for producers and consumers to the message metadata such as `correlation_id`, or as it was relevant to my use case, the `application_headers`.