### PR TITLE
Sets correlation ID for later use

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -93,11 +93,12 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
+        $this->message->set('correlation_id', uniqid());
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
 
-        return true;
+        return $this->message->get('correlation_id');
     }
 
     /**


### PR DESCRIPTION
As of now a message's `correlation_id` is not being set, causing `getJobId()` to throw an `OutOfBoundsException`. This PR ensures that this correlation ID is set by assigning it a `uniqid()` returning it. This allows Laravel applications to use it later on for whatever purposes (in our case, tracking the status of a job).

One possible addition to this would be allowing Laravel applications to set the job ID upon dispatch however I haven't been able to find a way for options to be passed to a queue driver. If anyone has any ideas for this please let me know (for reference [this](https://github.com/laravel/framework/blob/5.1/src/Illuminate/Foundation/Bus/DispatchesJobs.php) file caused my discouragement). 

Let me know if you have any feedback; I'm more than happy to polish this to get it merged in (hopefully this will be easy as this is a pretty minor diff)!