### PR TITLE
Correlation ID support fixes

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -132,7 +132,7 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string|false
+     * @return string|bool
      */
     public function getJobId()
     {

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -152,6 +152,6 @@ class RabbitMQJob extends Job implements JobContract
      */
     public function setJobId($id)
     {
-        $this->connection->setCorrelationid($id);
+        $this->connection->setCorrelationId($id);
     }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -132,11 +132,26 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string
+     * @return string|false
      */
     public function getJobId()
     {
-        return $this->message->get('correlation_id');
+        if ($this->message->has('correlation_id') === true) {
+            return $this->message->get('correlation_id');
+        }
+
+        return false;
     }
 
+    /**
+     * Sets the job identifier.
+     *
+     * @param string $id
+     *
+     * @return void
+     */
+    public function setJobId($id)
+    {
+        $this->connection->setCorrelationid($id);
+    }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -270,7 +270,7 @@ class RabbitMQQueue extends Queue implements QueueContract
     }
 
     /**
-     * Retrieves the correlation id, or a unique id
+     * Retrieves the correlation id, or a unique id.
      *
      * @return string
      */

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -256,7 +256,7 @@ class RabbitMQQueue extends Queue implements QueueContract
     }
 
     /**
-     * Sets the correlation id for a message to be published
+     * Sets the correlation id for a message to be published.
      *
      * @param string $id
      *

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -34,6 +34,11 @@ class RabbitMQQueue extends Queue implements QueueContract
     private $attempts;
 
     /**
+     * @var string
+     */
+    private $correlationId;
+
+    /**
      * @param AMQPStreamConnection $amqpConnection
      * @param array                $config
      */
@@ -93,7 +98,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
-        $this->message->set('correlation_id', uniqid());
+        $message->set('correlation_id', $this->correlationId ?: uniqid());
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
@@ -248,5 +253,17 @@ class RabbitMQQueue extends Queue implements QueueContract
     public function setAttempts($count)
     {
         $this->attempts = $count;
+    }
+
+    /**
+     * Sets the correlation id for a message to be published
+     *
+     * @param string $id
+     *
+     * @return void
+     */
+    public function setCorrelationId($id)
+    {
+        $this->correlationId = $id;
     }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -98,12 +98,14 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
-        $message->set('correlation_id', $this->correlationId ?: uniqid());
+
+        $correlationId = $this->getCorrelationId();
+        $message->set('correlation_id', $correlationId);
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
 
-        return $this->message->get('correlation_id');
+        return $correlationId;
     }
 
     /**
@@ -265,5 +267,15 @@ class RabbitMQQueue extends Queue implements QueueContract
     public function setCorrelationId($id)
     {
         $this->correlationId = $id;
+    }
+
+    /**
+     * Retrieves the correlation id, or a unique id
+     *
+     * @return string
+     */
+    public function getCorrelationId()
+    {
+        return $this->correlationId ?: uniqid();
     }
 }


### PR DESCRIPTION
 * Fixes correlation id support during publishing (this is currently broken on master).
 * Provides interface to support altering the job id during retry/failure conditions.