### PR TITLE
Backports correlation/job ID support from master into v5.2

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -160,10 +160,26 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string
+     * @return string|false
      */
     public function getJobId()
     {
-        return $this->message->get('correlation_id');
+        if ($this->message->has('correlation_id') === true) {
+            return $this->message->get('correlation_id');
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets the job identifier.
+     *
+     * @param string $id
+     *
+     * @return void
+     */
+    public function setJobId($id)
+    {
+        $this->connection->setCorrelationid($id);
     }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -160,7 +160,7 @@ class RabbitMQJob extends Job implements JobContract
     /**
      * Get the job identifier.
      *
-     * @return string|false
+     * @return string|bool
      */
     public function getJobId()
     {

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -180,6 +180,6 @@ class RabbitMQJob extends Job implements JobContract
      */
     public function setJobId($id)
     {
-        $this->connection->setCorrelationid($id);
+        $this->connection->setCorrelationId($id);
     }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -93,11 +93,12 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
+        $this->message->set('correlation_id', uniqid());
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
 
-        return true;
+        return $this->message->get('correlation_id');
     }
 
     /**

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -34,6 +34,11 @@ class RabbitMQQueue extends Queue implements QueueContract
     private $attempts;
 
     /**
+     * @var string
+     */
+    private $correlationId;
+
+    /**
      * @param AMQPStreamConnection $amqpConnection
      * @param array $config
      */
@@ -93,7 +98,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
-        $this->message->set('correlation_id', uniqid());
+        $message->set('correlation_id', $this->correlationId ?: uniqid());
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
@@ -249,5 +254,17 @@ class RabbitMQQueue extends Queue implements QueueContract
     public function setAttempts($count)
     {
         $this->attempts = $count;
+    }
+
+    /**
+     * Sets the correlation id for a message to be published
+     *
+     * @param string $id
+     *
+     * @return void
+     */
+    public function setCorrelationId($id)
+    {
+        $this->correlationId = $id;
     }
 }

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -271,7 +271,7 @@ class RabbitMQQueue extends Queue implements QueueContract
     }
 
     /**
-     * Retrieves the correlation id, or a unique id
+     * Retrieves the correlation id, or a unique id.
      *
      * @return string
      */

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -257,7 +257,7 @@ class RabbitMQQueue extends Queue implements QueueContract
     }
 
     /**
-     * Sets the correlation id for a message to be published
+     * Sets the correlation id for a message to be published.
      *
      * @param string $id
      *

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -98,12 +98,14 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // push job to a queue
         $message = new AMQPMessage($payload, $headers);
-        $message->set('correlation_id', $this->correlationId ?: uniqid());
+
+        $correlationId = $this->getCorrelationId();
+        $message->set('correlation_id', $correlationId);
 
         // push task to a queue
         $this->channel->basic_publish($message, $exchange, $queue);
 
-        return $this->message->get('correlation_id');
+        return $correlationId;
     }
 
     /**
@@ -266,5 +268,15 @@ class RabbitMQQueue extends Queue implements QueueContract
     public function setCorrelationId($id)
     {
         $this->correlationId = $id;
+    }
+
+    /**
+     * Retrieves the correlation id, or a unique id
+     *
+     * @return string
+     */
+    public function getCorrelationId()
+    {
+        return $this->correlationId ?: uniqid();
     }
 }


### PR DESCRIPTION
Backports the correlation id support from master into v5.2.

 * Tested on laravel/framework:v5.2.39