### PR TITLE
Convert DateTime to seconds

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -120,7 +120,7 @@ class RabbitMQQueue extends Queue implements QueueContract
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->pushRaw($this->createPayload($job, $data), $queue, ['delay' => $delay]);
+        return $this->pushRaw($this->createPayload($job, $data), $queue, ['delay' => $this->getSeconds($delay)]);
     }
 
     /**


### PR DESCRIPTION
When using a DateTime or Carbon object in the later method.
`ErrorException: Object of class Carbon\Carbon could not be converted to int in...`