### PR TITLE
declare exchange & queue one time only

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -175,7 +175,7 @@ class RabbitMQQueue extends Queue implements QueueContract
         $name = $this->getQueueName($name);
         $exchange = $this->configExchange['name'] ?: $name;
 
-        if ($this->declareExchange && !in_array($exchange, $this->declaredExchanges)) {
+        if ($this->declareExchange && ! in_array($exchange, $this->declaredExchanges)) {
             $this->declaredExchanges[] = $exchange;
             // declare exchange
             $this->channel->exchange_declare(
@@ -187,7 +187,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             );
         }
 
-        if ($this->declareBindQueue && !in_array($name, $this->declaredBindQueue)) {
+        if ($this->declareBindQueue && ! in_array($name, $this->declaredBindQueue)) {
             $this->declaredBindQueue[] = $name;
             // declare queue
             $this->channel->queue_declare(

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -22,7 +22,10 @@ class RabbitMQQueue extends Queue implements QueueContract
     protected $channel;
 
     protected $declareExchange;
+    protected $declaredExchanges = [];
+
     protected $declareBindQueue;
+    protected $declaredBindQueue = [];
 
     protected $defaultQueue;
     protected $configQueue;
@@ -172,7 +175,8 @@ class RabbitMQQueue extends Queue implements QueueContract
         $name = $this->getQueueName($name);
         $exchange = $this->configExchange['name'] ?: $name;
 
-        if ($this->declareExchange) {
+        if ($this->declareExchange && !in_array($exchange, $this->declaredExchanges)) {
+            $this->declaredExchanges[] = $exchange;
             // declare exchange
             $this->channel->exchange_declare(
                 $exchange,
@@ -183,7 +187,8 @@ class RabbitMQQueue extends Queue implements QueueContract
             );
         }
 
-        if ($this->declareBindQueue) {
+        if ($this->declareBindQueue && !in_array($name, $this->declaredBindQueue)) {
+            $this->declaredBindQueue[] = $name;
             // declare queue
             $this->channel->queue_declare(
                 $name,


### PR DESCRIPTION
declare exchange & queue one time only
It allows to increase queue income in hundreds times
before 
![image](https://cloud.githubusercontent.com/assets/8919533/17810281/dbc26da4-6624-11e6-8fda-39ecd5b73446.png)
after
![image](https://cloud.githubusercontent.com/assets/8919533/17810305/00580d5e-6625-11e6-8d2e-f5a30ee809b5.png)


I found params in your config `exchange_declare` and `queue_declare_bind`. But if set their values to false - they won't be created at all.