### PR TITLE
Added better error handling to rabbitmq connectors

### DIFF
--- a/src/config/rabbitmq.php
+++ b/src/config/rabbitmq.php
@@ -33,4 +33,5 @@ return [
         'auto_delete' 		=> env('RABBITMQ_EXCHANGE_AUTODELETE', false),
     ],
 
+    'sleep_on_error'        => env('RABBITMQ_ERROR_SLEEP', 5), // the number of seconds to sleep if there's an error communicating with rabbitmq
 ];


### PR DESCRIPTION
If the RabbitMQ connector was unavailable, and the queue was running in daemon mode, the error log would flood within seconds. This reports the connection error responsibly, and sleeps to stop the log file from being instantly flooded.

This is against the 5.1 branch, as I'm using that branch (because of Laravel LTS being 5.1), but I am happy to also send a similar update to the 5.2 and/or 5.3 branches.
