### PR TITLE
BugFix - Added missing connectionName.

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/Jobs/RabbitMQJob.php
@@ -35,19 +35,22 @@ class RabbitMQJob extends Job implements JobContract
      * @param \PhpAmqpLib\Channel\AMQPChannel                             $channel
      * @param string                                                      $queue
      * @param \PhpAmqpLib\Message\AMQPMessage                             $message
+     * @param string                                                      $connectionName
      */
     public function __construct(
         Container $container,
         RabbitMQQueue $connection,
         AMQPChannel $channel,
         $queue,
-        AMQPMessage $message
+        AMQPMessage $message,
+        $connectionName
     ) {
         $this->container = $container;
         $this->connection = $connection;
         $this->channel = $channel;
         $this->queue = $queue;
         $this->message = $message;
+        $this->connectionName = $connectionName;
     }
 
     /**

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -165,8 +165,14 @@ class RabbitMQQueue extends Queue implements QueueContract
             $message = $this->channel->basic_get($queue);
 
             if ($message instanceof AMQPMessage) {
-                return new RabbitMQJob($this->container, $this, $this->channel,
-                    $queue, $message, $this->connectionName);
+                return new RabbitMQJob(
+                    $this->container,
+                    $this,
+                    $this->channel,
+                    $queue,
+                    $message,
+                    $this->connectionName
+                );
             }
         } catch (ErrorException $exception) {
             $this->reportConnectionError('pop', $exception);

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -165,7 +165,8 @@ class RabbitMQQueue extends Queue implements QueueContract
             $message = $this->channel->basic_get($queue);
 
             if ($message instanceof AMQPMessage) {
-                return new RabbitMQJob($this->container, $this, $this->channel, $queue, $message, $this->connectionName);
+                return new RabbitMQJob($this->container, $this, $this->channel,
+                    $queue, $message, $this->connectionName);
             }
         } catch (ErrorException $exception) {
             $this->reportConnectionError('pop', $exception);

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -165,7 +165,7 @@ class RabbitMQQueue extends Queue implements QueueContract
             $message = $this->channel->basic_get($queue);
 
             if ($message instanceof AMQPMessage) {
-                return new RabbitMQJob($this->container, $this, $this->channel, $queue, $message);
+                return new RabbitMQJob($this->container, $this, $this->channel, $queue, $message, $this->connectionName);
             }
         } catch (ErrorException $exception) {
             $this->reportConnectionError('pop', $exception);


### PR DESCRIPTION
When calling $this->fail() inside a RabbitMQ job it fails because the connectionName is NULL.

I have looked at how core laravel jobs does it and this is how. :)

`
Next exception 'Illuminate\Database\QueryException' with message 'SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'connection' cannot be null (SQL: insert into failed_jobs (connection, queue, payload, exception, failed_at) .....
`
