### PR TITLE
Changed visibility of RabbitMQQueue::reportConnectionError 

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -325,7 +325,7 @@ class RabbitMQQueue extends Queue implements QueueContract
      * @param string    $action
      * @param Exception $e
      */
-    private function reportConnectionError($action, Exception $e)
+    protected function reportConnectionError($action, Exception $e)
     {
         Log::error('AMQP error while attempting '.$action.': '.$e->getMessage());
         // Sleep so that we don't flood the log file


### PR DESCRIPTION
This allow to override log operation through static aka "facade" Log to use this lib not only with full Laravel framework. I think it would be nice to make all private methods of RabbitMQQueue protected, but currently only reportConnectionError use hidden external dependency.