### PR TITLE
Fix for lost connections with RabbitMQ

### DIFF
--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -332,7 +332,7 @@ class RabbitMQQueue extends Queue implements QueueContract
 
         // If it's set to false, throw an error rather than waiting
         if ($this->sleepOnError === false) {
-            throw new \Exception('Error writing data to the connection with RabbitMQ');
+            throw new \RuntimeException('Error writing data to the connection with RabbitMQ');
         }
 
         // Sleep so that we don't flood the log file

--- a/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
+++ b/src/VladimirYuldashev/LaravelQueueRabbitMQ/Queue/RabbitMQQueue.php
@@ -324,10 +324,17 @@ class RabbitMQQueue extends Queue implements QueueContract
     /**
      * @param string    $action
      * @param Exception $e
+     * @throws Exception
      */
     protected function reportConnectionError($action, Exception $e)
     {
         Log::error('AMQP error while attempting '.$action.': '.$e->getMessage());
+
+        // If it's set to false, throw an error rather than waiting
+        if ($this->sleepOnError === false) {
+            throw new \Exception('Error writing data to the connection with RabbitMQ');
+        }
+
         // Sleep so that we don't flood the log file
         sleep($this->sleepOnError);
     }

--- a/src/config/rabbitmq.php
+++ b/src/config/rabbitmq.php
@@ -40,6 +40,8 @@ return [
         'auto_delete' => env('RABBITMQ_EXCHANGE_AUTODELETE', false),
     ],
 
-    'sleep_on_error' => env('RABBITMQ_ERROR_SLEEP', 5), // the number of seconds to sleep if there's an error communicating with rabbitmq
+    // the number of seconds to sleep if there's an error communicating with rabbitmq
+    // if set to false, it'll throw an exception rather than doing the sleep for X seconds
+    'sleep_on_error' => env('RABBITMQ_ERROR_SLEEP', 5),
 
 ];


### PR DESCRIPTION
At the moment, if a queue worker is running while a connection error happens to RabbitMQ, the worker becomes corrupted and cannot process data correctly anymore.

The job being run by the worker is never marked as failed, it also does not work anymore even if the connection to RabbitMQ is restored.

This fix allows to optionally throw an exception if this scenario happens and the worker will be killed by Laravel.
Then if used along with Supervisor, a new worker is spawned and new connection will be established allowing the system to work again.